### PR TITLE
Fix build without all features enabled

### DIFF
--- a/Multiplatform/MultiplatformApp.swift
+++ b/Multiplatform/MultiplatformApp.swift
@@ -15,10 +15,6 @@ struct MultiplatformApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
-        #if !ENABLE_ALL_FEATURES
-        ENABLE_ALL_FEATURES = false
-        #endif
-        
         ImagePipeline.shared = ImagePipeline(configuration: .withDataCache)
         
         BackgroundTaskHandler.setup()


### PR DESCRIPTION
When ENABLE_ALL_FEATURES is removed from the debug configuration, the build would fail due to an ifdef assigning to a non-existing variable. Fix this by removing the assignment.
