### PR TITLE
Fix comments in debug config template

### DIFF
--- a/Configuration/Debug.xcconfig.template
+++ b/Configuration/Debug.xcconfig.template
@@ -10,12 +10,12 @@
 
 #include "Base.xcconfig"
 
-# REMOVE "ENABLE_ALL_FEATURES" IF YOU DON'T HAVE A PAID DEVELOPER ACCOUNT
+// REMOVE "ENABLE_ALL_FEATURES" IF YOU DON'T HAVE A PAID DEVELOPER ACCOUNT
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG ENABLE_ALL_FEATURES
 
 DEVELOPMENT_TEAM = ABC123456
 BUNDLE_ID_PREFIX = change.me
 
-# ShelfPlayer uses two entitlements only available to paid or even authorized developers.
-# This line uses an alternate set of entitlements, which should be available to everyone.
+// ShelfPlayer uses two entitlements only available to paid or even authorized developers.
+// This line uses an alternate set of entitlements, which should be available to everyone.
 CODE_SIGN_ENTITLEMENTS = Configuration/Alternative.entitlements


### PR DESCRIPTION
The comments in the debug config template were accidentally prefixed
with # rather than //, which is used by .xcconfig files.

The error thrown by Xcode: `unsupported preprocessor directive ‘REMOVE’`.