### PR TITLE
Fix german "authors" translation

### DIFF
--- a/Multiplatform/Localizable.xcstrings
+++ b/Multiplatform/Localizable.xcstrings
@@ -4712,7 +4712,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Authoren"
+            "value" : "Autoren"
           }
         },
         "en" : {
@@ -5986,7 +5986,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neuste Authoren"
+            "value" : "Neuste Autoren"
           }
         },
         "en" : {


### PR DESCRIPTION
Hey, thanks for this great app! I recognized a small typo in the word "author" in the german translation, hence opening a PR to fix it :)