### PR TITLE
Fix track.index nil error messages with custom podcast

### DIFF
--- a/ShelfPlayerKit/Sources/SPNetwork/Convert/PlayableItem+Convert.swift
+++ b/ShelfPlayerKit/Sources/SPNetwork/Convert/PlayableItem+Convert.swift
@@ -11,7 +11,7 @@ import SPFoundation
 internal extension PlayableItem.AudioTrack {
     init(track: AudiobookshelfAudioTrack) {
         self.init(
-            index: track.index!,
+            index: track.index ?? 0, 
             offset: track.startOffset,
             duration: track.duration,
             codec: track.codec,


### PR DESCRIPTION
Hi,

I have a few custom podcasts (The podcasts from one company I listen to make me use their own app, so I have a script that pulls the mp3 from the server and host it myself on ABS). 

Those podcasts play without issue in Audiobookshelf, but not in ShelfPlayer.
I added 0 as a default value and those podcasts now play without issue now on ShelfPlayer.

Thanks,
Olivier  