### PR TITLE
Passes namespace from the content view

### DIFF
--- a/Multiplatform/Playback/RegularPlaybackModifier.swift
+++ b/Multiplatform/Playback/RegularPlaybackModifier.swift
@@ -137,6 +137,7 @@ struct RegularPlaybackModifier: ViewModifier {
     @Environment(\.playbackBottomOffset) private var playbackBottomOffset
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.namespace) private var namespace
     
     @Environment(PlaybackViewModel.self) private var viewModel
     @Environment(Satellite.self) private var satellite
@@ -234,6 +235,7 @@ struct RegularPlaybackModifier: ViewModifier {
                     }
                     .environment(Satellite.shared)
                     .environment(PlaybackViewModel.shared)
+                    .environment(\.namespace, namespace)
                 }
         } else {
             content


### PR DESCRIPTION
The namespace was not being passed down from the content view, which caused a crash on macOS. This commit fixes the crash by passing the namespace.