### PR TITLE
Fix inverted offline mode logic preventing online connection

### DIFF
--- a/Multiplatform/Navigation/TabRouterViewModel.swift
+++ b/Multiplatform/Navigation/TabRouterViewModel.swift
@@ -69,7 +69,7 @@ final class TabRouterViewModel: Sendable {
 
         logger.info("Loading online UI")
         
-        let allConnectionsUnavailable = await withTaskGroup {
+        let anyConnectionSucceeded = await withTaskGroup {
             for connectionID in await PersistenceManager.shared.authorization.connectionIDs {
                 logger.info("Loading connection: \(connectionID)")
                 
@@ -103,10 +103,10 @@ final class TabRouterViewModel: Sendable {
                 }
             }
             
-            return await $0.reduce(true) { $0 && $1 }
+            return await $0.reduce(false) { $0 || $1 }
         }
-        
-        if allConnectionsUnavailable {
+
+        if !anyConnectionSucceeded {
             await OfflineMode.shared.setEnabled(true)
         }
     }


### PR DESCRIPTION
## Problem

The app was incorrectly entering offline mode even when server connections succeeded. Users would see the offline mode UI despite having working network connectivity to their server.

## Root Cause

In `TabRouterViewModel.swift`, the `loadLibraries()` function had inverted boolean logic:

```swift
// Before (broken):
let allConnectionsUnavailable = await withTaskGroup(of: Bool.self) { group in
    // ... tasks return true on success, false on failure
    return await group.reduce(true) { $0 && $1 }
}

if allConnectionsUnavailable {
    await OfflineMode.shared.setEnabled(true)
}
```

The issue:
- `reduce(true) { $0 && $1 }` returns `true` only when **ALL** connections succeed
- But the variable was named `allConnectionsUnavailable` and triggered offline mode when `true`
- This caused the app to go offline when connections worked, and stay online when they failed

## Solution

```swift
// After (fixed):
let anyConnectionSucceeded = await withTaskGroup(of: Bool.self) { group in
    // ... tasks return true on success, false on failure
    return await group.reduce(false) { $0 || $1 }
}

if !anyConnectionSucceeded {
    await OfflineMode.shared.setEnabled(true)
}
```

Changes:
- Renamed variable to `anyConnectionSucceeded` for clarity
- Changed reduction to OR (`||`) with initial value `false`
- Now correctly enables offline mode only when **no** connection succeeded

## Test Plan

- [ ] Launch app with valid server connection → should stay online and show library
- [ ] Launch app with no network → should enter offline mode
- [ ] Launch app with invalid server URL → should enter offline mode

---

🤖 Generated with [Claude Code](https://claude.ai/code)