### PR TITLE
Use URL keyboard type for server endpoint input

### DIFF
--- a/Multiplatform/Connection/ConnectionAddSheet.swift
+++ b/Multiplatform/Connection/ConnectionAddSheet.swift
@@ -23,6 +23,7 @@ struct ConnectionAddSheet: View {
             Form {
                 Section {
                     TextField("connection.add.endpoint", text: $viewModel.endpoint)
+                        .keyboardType(.URL)
                         .textContentType(.URL)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)


### PR DESCRIPTION
## Problem

When adding a new server connection, users need to enter a URL (e.g., `https://audiobooks.example.com`). The standard keyboard makes this tedious because:
- The `.` key requires switching to the symbols keyboard
- No quick access to `/` or common TLDs like `.com`

## Solution

Added `.keyboardType(.URL)` to the server endpoint TextField in `ConnectionAddSheet.swift`.

### Before
```swift
TextField("connection.add.endpoint", text: $viewModel.endpoint)
    .textContentType(.URL)
    .autocorrectionDisabled()
    .textInputAutocapitalization(.never)
```

### After
```swift
TextField("connection.add.endpoint", text: $viewModel.endpoint)
    .keyboardType(.URL)  // ← Added
    .textContentType(.URL)
    .autocorrectionDisabled()
    .textInputAutocapitalization(.never)
```

## Result

The URL keyboard provides:
- Direct access to `.` on the main keyboard
- Quick access to `/`
- `.com` button (and other TLDs via long press)
- Better UX for entering server addresses

## Test Plan

- [ ] Open "Add Connection" sheet
- [ ] Tap on the URL field
- [ ] Verify URL keyboard appears with `.`, `/`, and `.com` easily accessible

---

🤖 Generated with [Claude Code](https://claude.ai/code)