### PR TITLE
Fix synchronisation issues when loading multiple libraries

### DIFF
--- a/Multiplatform/Navigation/TabRouterViewModel.swift
+++ b/Multiplatform/Navigation/TabRouterViewModel.swift
@@ -34,9 +34,12 @@ final class TabRouterViewModel: Sendable {
     private(set) var pinnedTabValues: [TabValue]
     
     // MARK: Synchronise
-    
+
     private(set) var currentConnectionStatus = [ItemIdentifier.ConnectionID: Bool]()
     private(set) var activeUpdateTasks = [ItemIdentifier.ConnectionID: Task<Void, Never>]()
+    private(set) var initialSyncCompleted = [ItemIdentifier.ConnectionID: Bool]()
+
+    private(set) var isLoadingLibraries = false
     
     // MARK: Helper
     
@@ -67,47 +70,55 @@ final class TabRouterViewModel: Sendable {
     nonisolated func loadLibraries() async {
         var shouldContinue = true
 
+        await MainActor.run {
+            isLoadingLibraries = true
+        }
+
         logger.info("Loading online UI")
-        
-        let allConnectionsUnavailable = await withTaskGroup {
+
+        let allConnectionsAvailable = await withTaskGroup {
             for connectionID in await PersistenceManager.shared.authorization.connectionIDs {
                 logger.info("Loading connection: \(connectionID)")
-                
+
                 $0.addTask {
                     do {
                         let libraries = try await ABSClient[connectionID].libraries()
                         var results = [Library: ([TabValue], [TabValue])]()
-                        
+
                         self.logger.info("Got libraries for connection: \(connectionID)")
-                        
+
                         for library in libraries {
                             let (tabBar, sideBar) = (
                                 await PersistenceManager.shared.customization.configuredTabs(for: library.id, scope: .tabBar),
                                 await PersistenceManager.shared.customization.configuredTabs(for: library.id, scope: .sidebar),
                             )
-                            
+
                             results[library] = (tabBar, sideBar)
                         }
-                        
+
                         await self.synchronize(connectionID: connectionID)
                         self.logger.info("Syncrhonized connection: \(connectionID)")
-                        
+
                         await self.didLoad(connectionID: connectionID, libraries: results)
                         return true
                     } catch {
                         self.logger.info("Failed to load libraries for connection: \(connectionID)")
-                        
+
                         await self.synchronizeFailed(connectionID: connectionID)
                         return false
                     }
                 }
             }
-            
+
             return await $0.reduce(true) { $0 && $1 }
         }
-        
-        if allConnectionsUnavailable {
+
+        if !allConnectionsAvailable {
             await OfflineMode.shared.setEnabled(true)
+        }
+
+        await MainActor.run {
+            isLoadingLibraries = false
         }
     }
 }
@@ -205,21 +216,47 @@ private extension TabRouterViewModel {
             selectFirstCompactTab(for: .convertItemIdentifierToLibraryIdentifier(navigateToWhenReady), allowPinned: true)
             return true
         }
-        
-        guard let lastTabValue = Defaults[.lastTabValue] else {
-            return false
-        }
-        
-        if let libraryID = lastTabValue.libraryID {
-            guard libraries.contains(where: { $0.id == libraryID }) else {
-                return false
+
+        // Prioritize lastPlayedItemID (show the library where the pill item belongs)
+        if let lastPlayedItemID = Defaults[.lastPlayedItemID] {
+            let targetLibraryID = LibraryIdentifier.convertItemIdentifierToLibraryIdentifier(lastPlayedItemID)
+
+            if libraries.contains(where: { $0.id == targetLibraryID }) {
+                logger.info("Restoring library from lastPlayedItemID: \(targetLibraryID.connectionID)")
+
+                // Check if lastTabValue exists and matches the same library - use the specific tab
+                if let lastTabValue = Defaults[.lastTabValue],
+                   lastTabValue.libraryID == targetLibraryID {
+                    logger.info("Restoring specific tab within same library from lastTabValue")
+                    tabValue = lastTabValue
+                } else {
+                    // Use first tab of the library where the played item belongs
+                    logger.info("Selecting first tab of library where played item belongs")
+                    selectFirstCompactTab(for: targetLibraryID, allowPinned: true)
+                }
+                return true
+            } else {
+                logger.info("Library for lastPlayedItemID not available: \(targetLibraryID.connectionID)")
             }
-        } else {
-            selectedLibraryID = libraries.first?.id
         }
-        
-        tabValue = lastTabValue
-        return true
+
+        // Fall back to lastTabValue if no lastPlayedItemID
+        if let lastTabValue = Defaults[.lastTabValue] {
+            if let libraryID = lastTabValue.libraryID {
+                guard libraries.contains(where: { $0.id == libraryID }) else {
+                    logger.info("Library for lastTabValue not available: \(libraryID.id)")
+                    return false
+                }
+            } else {
+                selectedLibraryID = libraries.first?.id
+            }
+
+            logger.info("Restoring from lastTabValue as fallback")
+            tabValue = lastTabValue
+            return true
+        }
+
+        return false
     }
     
     func didLoad(connectionID: ItemIdentifier.ConnectionID, libraries: [Library: ([TabValue], [TabValue])]) {
@@ -240,43 +277,68 @@ private extension TabRouterViewModel {
 // MARK: Sync
 
 extension TabRouterViewModel {
-    func synchronize(connectionID: ItemIdentifier.ConnectionID) {
-        guard activeUpdateTasks[connectionID] == nil else {
-            logger.warning("Tried to start sync for \(connectionID) while it is already running")
-            return
-        }
-        
-        activeUpdateTasks[connectionID] = .init { [weak self] in
-            let success: Bool
-            let task = UIApplication.shared.beginBackgroundTask(withName: "synchronizeUserData")
-            
-            do {
-                let (sessions, bookmarks) = try await ABSClient[connectionID].authorize()
-                
-                try await withThrowingTaskGroup(of: Void.self) {
-                    $0.addTask { try await PersistenceManager.shared.progress.compareDatabase(against: sessions, connectionID: connectionID) }
-                    $0.addTask { try await PersistenceManager.shared.bookmark.sync(bookmarks: bookmarks, connectionID: connectionID) }
-                    
-                    try await $0.waitForAll()
+    func synchronize(connectionID: ItemIdentifier.ConnectionID) async {
+        // Atomically check for existing task or create new one on MainActor
+        let task = await MainActor.run { () -> Task<Void, Never> in
+            // If there's already a task running, return it
+            if let existingTask = activeUpdateTasks[connectionID] {
+                logger.info("Sync already running for \(connectionID), awaiting existing task")
+                return existingTask
+            }
+
+            let isInitialSync = initialSyncCompleted[connectionID] != true
+
+            // Create the task
+            let newTask: Task<Void, Never> = .init { [weak self] in
+                let success: Bool
+                let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "synchronizeUserData")
+
+                do {
+                    let (sessions, bookmarks) = try await ABSClient[connectionID].authorize()
+
+                    try await withThrowingTaskGroup(of: Void.self) {
+                        $0.addTask {
+                            try await PersistenceManager.shared.progress.compareDatabase(
+                                against: sessions,
+                                connectionID: connectionID,
+                                isInitialSync: isInitialSync
+                            )
+                        }
+                        $0.addTask { try await PersistenceManager.shared.bookmark.sync(bookmarks: bookmarks, connectionID: connectionID) }
+
+                        try await $0.waitForAll()
+                    }
+
+                    success = true
+                } catch {
+                    self?.logger.error("Failed to synchronize \(connectionID, privacy: .public): \(error, privacy: .public)")
+                    success = false
                 }
-                
-                success = true
-            } catch {
-                self?.logger.error("Failed to synchronize \(connectionID, privacy: .public): \(error, privacy: .public)")
-                success = false
+
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+
+                guard !Task.isCancelled, let self else {
+                    return
+                }
+
+                await MainActor.withAnimation {
+                    currentConnectionStatus[connectionID] = success
+                    activeUpdateTasks[connectionID] = nil
+
+                    // Mark initial sync as complete
+                    if success && isInitialSync {
+                        initialSyncCompleted[connectionID] = true
+                    }
+                }
             }
-            
-            UIApplication.shared.endBackgroundTask(task)
-            
-            guard !Task.isCancelled, let self else {
-                return
-            }
-            
-            await MainActor.withAnimation {
-                currentConnectionStatus[connectionID] = success
-                activeUpdateTasks[connectionID] = nil
-            }
+
+            // Store the task atomically
+            activeUpdateTasks[connectionID] = newTask
+            return newTask
         }
+
+        // Await the task (either existing or newly created)
+        await task.value
     }
     func synchronizeFailed(connectionID: ItemIdentifier.ConnectionID) {
         currentConnectionStatus[connectionID] = false


### PR DESCRIPTION
Hi! I was experiencing with some state problems when dealing with multiple libraries. In my setup, I have a children library and a normal library, and sometimes the app just restored in the "wrong" library, although showing the resume playback pill from another library, and sometimes also forgetting my listening process.

I am not Swift developer at all, do not know the codebase at all, but have 20 years of software development experience, and decided to try to fix these issues with Claude Code. The result of this experiment is in this PR, and I would ask you to please check this out, and make the call yourself as the Real Swift Developer™️, if these changes actually make sense 😅 On a superficial level these do look quite legit, and on my brief testing with an emulator and with a device, the synchronisation issues seemed to decrease. The original situation felt like a race condition, and Claude Code was multiple times referring to these changes fixing a race condition in the initial syncronization.

The part that I am not very much not sure, are the changes to `ShelfPlayerKit/Persistence/ProgressSubsystem.swift`. I do not completely understand what is happening there, but the change did seem to fix the issue of progress being lost from time to time.

Hopefully these _vibecodings_ of mine are at least remotely helpful for you :)

## Issues fixed, according to CC

1. Race Condition in Connection Synchronization
2. Incorrect Offline Mode Activation
3. Library Restoration Not Matching Playback Pill
4. Race Condition with Multiple Libraries Loading
5. Resume Pill Showing Before Initial Sync Complete
6. Progress Entities Deleted During Initial Sync