### PR TITLE
Possibly Fix CarPlay steering wheel buttons not responding

### DIFF
--- a/ShelfPlayback/AudioPlayer+Update.swift
+++ b/ShelfPlayback/AudioPlayer+Update.swift
@@ -167,6 +167,7 @@ extension AudioPlayer {
     }
     
     func isBusyDidChange() async {
+        await widgetManager.update(isBuffering: isBusy)
         await RFNotification[.bufferHealthChanged].send(payload: isBusy)
     }
 }

--- a/ShelfPlayback/AudioPlayer.swift
+++ b/ShelfPlayback/AudioPlayer.swift
@@ -467,18 +467,26 @@ private extension AudioPlayer {
             return .success
         }
         
-        commandCenter.seekBackwardCommand.addTarget { _ in
+        commandCenter.seekBackwardCommand.addTarget { event in
+            guard (event as? MPSeekCommandEvent)?.type == .beginSeeking else {
+                return .success
+            }
+
             Task {
                 try await self.skip(forwards: false)
             }
-            
+
             return .success
         }
-        commandCenter.seekForwardCommand.addTarget { _ in
+        commandCenter.seekForwardCommand.addTarget { event in
+            guard (event as? MPSeekCommandEvent)?.type == .beginSeeking else {
+                return .success
+            }
+
             Task {
                 try await self.skip(forwards: true)
             }
-            
+
             return .success
         }
         


### PR DESCRIPTION
Hi! I'm just getting back into listening to audiobooks, so I searched for open-source clients of Audiobookshelf and thought "Hey, I should contribute back to the community, the way I did back in the KDE2 days". So here I am. 👋 

This PR is to (hopefully!) fix https://github.com/rasmuslos/ShelfPlayer/issues/265 and https://github.com/rasmuslos/ShelfPlayer/issues/426

The first bug, while real (as far as I can tell) is a *maybe* as to whether or not it causes the user reports of "my steering wheel buttons don't work". I don't have access to their vehicles and I can't, for love or money, find solid documentation on exactly how CarPlay interprets the .interrupted state. But it's at least plausible as a cause, and fixing the race condition shouldn't hurt.

The second bug is much more clean, in terms of "I'm 99% sure this is the issue" but there's only the one user report in #265 about "holding down seek acts weirdly" to go off of. An alternative would be to implement hold-to-seek for those vehicles who support those commands, but that's a bigger feature and I was trying to do the simplest/smallest possible fix.

And yes, as per your request/message in the README, while I had Claude helping me out (quite a bit!) I *am* a real human who wrote all of the words up to this point and reviewed the very small amount of code in the PR. The rest of this message is Claude-generated because I have old man hands and typing that much technical info is painful, but it was all reviewed by me as well.



Two bugs *possibly* caused CarPlay physical buttons (steering wheel skip/seek) to fail for many users, while on-screen CarPlay controls continued working.

Bug 1: MPNowPlayingInfoCenter.playbackState stuck at .interrupted

NowPlayingWidgetManager.isBuffering was rarely set to false after startup due to a race condition between buffer health checks and activeOperationCount:

During LocalAudioEndpoint.start(), activeOperationCount is >0 while the endpoint initializes. The 1-second buffer health timer detects the buffer is healthy and calls bufferHealthDidChange(), but that method passes AudioPlayer.isBusy (which combines isBuffering AND activeOperationCount) to the widget manager -- so the widget still sees isBuffering=true.

When the timer fires again, the endpoint's isBuffering hasn't changed (it's already false), so bufferHealthDidChange() is not called again.

When start() finishes and activeOperationCount drops to 0, isBusyDidChange() fires -- but it only sent a notification. It did NOT update the widget manager. The timer was also cancelled at this point (endpoint's isBuffering is already false). No remaining code path would ever set the widget's isBuffering to false, unless the buffer completely drains via a network drop-out or something similar.

Result: playbackState is stuck at .interrupted (meaning "interrupted by another app, like a phone call") for the entire playback session, when it should be .playing. This is the state the system uses to represent the app in Control Center, Lock Screen, and CarPlay. Reporting .interrupted while actually playing is incorrect and is possibly the cause of steering wheel buttons not responding, since the system may not route hardware remote command events to an app that reports its playback as interrupted.

Fix: isBusyDidChange() now updates the widget manager with the current isBusy state, matching what bufferHealthDidChange() already does.

Bug 2: Seek command handlers fire skip twice per button press

Different vehicles send different MPRemoteCommandCenter commands for their steering wheel forward/back buttons. Vehicles that send skipForwardCommand/skipBackwardCommand (MPSkipIntervalCommand) or nextTrackCommand/previousTrackCommand work correctly -- one skip per press. But vehicles that send seekForwardCommand/seekBackwardCommand deliver MPSeekCommandEvent, which has a .type property: .beginSeeking when pressed, .endSeeking when released. The handlers ignored this and called skip() on both events, causing a double-skip per press. This explains the one user report of "long press and release seems to trigger ff/rw oddly" while most other users reported no response at all (Bug 1 masked Bug 2 for them).

Fix: Guard on .beginSeeking, ignore .endSeeking.