### PR TITLE
Fix skip commands not responding to AirPods and CarPlay wheel controls

### DIFF
--- a/ShelfPlayback/AudioPlayer.swift
+++ b/ShelfPlayback/AudioPlayer.swift
@@ -473,7 +473,7 @@ private extension AudioPlayer {
             return .success
         }
         
-        commandCenter.previousTrackCommand.isEnabled = false
+        commandCenter.previousTrackCommand.isEnabled = true
         commandCenter.previousTrackCommand.addTarget { _ in
             Task {
                 do {
@@ -486,7 +486,7 @@ private extension AudioPlayer {
             return .success
         }
         
-        commandCenter.nextTrackCommand.isEnabled = false
+        commandCenter.nextTrackCommand.isEnabled = true
         commandCenter.nextTrackCommand.addTarget { _ in
             Task {
                 do {


### PR DESCRIPTION
## Summary
- `nextTrackCommand` and `previousTrackCommand` were registered with targets but had `isEnabled = false`, so hardware skip controls on AirPods and CarPlay were silently ignored
- Enabling both commands restores skip-by-interval behavior for these hardware controls

## Background
This is a regression from commit `137ada2a` ("Better remote command handling", Mar 17 2026), which deliberately disabled both commands — with the apparent intent of repurposing `nextTrackCommand` to call `advance()` (skip to next item) rather than skip by interval. However, a subsequent commit re-wired both targets back to `skip(forwards:)` without re-enabling the commands, leaving them dead.

This PR takes the position that hardware wheel/button controls should **skip by interval** (matching `skipForwardCommand`/`skipBackwardCommand`) rather than advance to the next item — consistent with how the app behaved before the rewrite and matching user expectations for audiobook playback. If the intent is instead to have these controls advance to the next chapter/item, the targets would need to be updated accordingly.

## Test plan
- [ ] Test skip forward/backward with AirPods double/triple tap
- [ ] Test skip forward/backward with CarPlay wheel controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)